### PR TITLE
Add local API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ To connect the Chrome extension to a local server for proxying connections:
 5. Click "Connect" to establish the connection
 6. The status indicator should change to "Connected" if successful
 
+### Local Chat Completion API Server
+
+A minimal server is included to expose an OpenAI compatible API. Start it with:
+
+```bash
+pnpm -F @extension/api-server start
+```
+
+It listens on `http://localhost:3007`. POST chat requests to `/v1/chat/completions` and the extension will insert the messages and return the response.
+
 ## Usage
 
 1. Navigate to a supported AI platform.

--- a/packages/api-server/index.mts
+++ b/packages/api-server/index.mts
@@ -1,0 +1,81 @@
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import { randomUUID } from 'crypto';
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+interface PendingRequest {
+  resolve: (content: string) => void;
+  reject: (err: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+const sseClients = new Set<express.Response>();
+const pendingRequests = new Map<string, PendingRequest>();
+
+app.get('/sse', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write('\n');
+  sseClients.add(res);
+  req.on('close', () => {
+    sseClients.delete(res);
+  });
+});
+
+function broadcast(event: unknown) {
+  const data = `data: ${JSON.stringify(event)}\n\n`;
+  for (const client of sseClients) {
+    client.write(data);
+  }
+}
+
+app.post('/v1/chat/completions', (req, res) => {
+  const { messages } = req.body ?? {};
+  if (!Array.isArray(messages)) {
+    res.status(400).json({ error: 'invalid request' });
+    return;
+  }
+  const id = randomUUID();
+  broadcast({ type: 'CHAT_COMPLETION_REQUEST', id, messages });
+
+  const timeout = setTimeout(() => {
+    pendingRequests.delete(id);
+    res.status(504).json({ error: 'timeout' });
+  }, 30000);
+
+  pendingRequests.set(id, {
+    resolve(content) {
+      clearTimeout(timeout);
+      res.json({ id, choices: [{ message: { role: 'assistant', content } }] });
+    },
+    reject(err) {
+      clearTimeout(timeout);
+      res.status(500).json({ error: err.message });
+    },
+    timeout,
+  });
+});
+
+app.post('/v1/response', (req, res) => {
+  const { id, content } = req.body ?? {};
+  const pending = pendingRequests.get(id);
+  if (!pending) {
+    res.status(400).json({ error: 'unknown id' });
+    return;
+  }
+  pendingRequests.delete(id);
+  pending.resolve(String(content ?? ''));
+  res.json({ ok: true });
+});
+
+const port = 3007;
+app.listen(port, () => {
+  console.log(`API server listening on http://localhost:${port}`);
+});

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@extension/api-server",
+  "version": "0.1.0",
+  "description": "Local API server for SuperAssistant",
+  "type": "module",
+  "private": true,
+  "sideEffects": false,
+  "scripts": {
+    "start": "tsx index.mts"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2"
+  },
+  "devDependencies": {
+    "@extension/tsconfig": "workspace:*",
+    "tsx": "^4.19.2"
+  }
+}

--- a/packages/api-server/tsconfig.json
+++ b/packages/api-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@extension/tsconfig/module",
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "."
+  },
+  "include": ["index.mts"]
+}


### PR DESCRIPTION
## Summary
- implement local Node.js service to expose an OpenAI-compatible chat completion API
- document how to run the local API server

## Testing
- `pnpm lint` *(fails: `turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a75f2cd88320979371cff0e63c7c