### PR TITLE
Add API server integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ WORKDIR /workspace
 COPY mcpconfig.yaml /mcpconfig.json
 
 # 4. Install the MCP SuperAssistant proxy globally
-RUN npm install -g @srbhptl39/mcp-superassistant-proxy@latest
+RUN npm install -g @srbhptl39/mcp-superassistant-proxy@latest tsx express cors body-parser
+
+# Copy API server
+COPY packages/api-server /api-server
 
 # 5. Expose the SSE port
+EXPOSE 3000
 EXPOSE 3006
 EXPOSE 3007
 
@@ -25,5 +29,6 @@ EXPOSE 3007
 ENTRYPOINT ["sh","-c", "\
   WORKDIR=\"${1:-/workspace}\"; \
   shift; \
+  tsx /api-server/index.mts & \
   exec mcp-superassistant-proxy --config \"/mcpconfig.json\" \"$@\"\
 ","-"]

--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -33,6 +33,7 @@ const manifest = {
     '*://*.chat.openai.com/*',
     '*://*.chatgpt.com/*',
     '*://*.grok.com/*',
+    'http://localhost:3000/*',
     '*://*.x.com/*',
     '*://*.twitter.com/*',
     '*://*.gemini.google.com/*',


### PR DESCRIPTION
## Summary
- include local API server in Docker build
- grant extension access to the API server
- connect background service worker to API server via SSE
- forward chat completion requests to active chatgpt/grok page and send back responses
- handle chat completion requests inside content script

## Testing
- `pnpm test` *(fails: Unsupported environment)*
- `npm test` *(fails: Missing script)*
- `pnpm lint` *(fails: Unsupported environment)*

------
https://chatgpt.com/codex/tasks/task_e_6845b92e6f388320b61f2c2177a46de4